### PR TITLE
Fix transfer label field

### DIFF
--- a/src/cgi-bin/rdaGlobusTransfer.py
+++ b/src/cgi-bin/rdaGlobusTransfer.py
@@ -124,7 +124,7 @@ def transfer(form):
         'label': ''
     }
 
-    browse_endpoint = 'https://www.globus.org/app/browse-endpoint?{}'.format(urlencode(params))
+    browse_endpoint = '{0}browse-endpoint?{1}'.format(MyGlobus['globusURL'], urlencode(params))
     print "Location: {0}\r\n\r\n".format(browse_endpoint)
 
     return
@@ -256,7 +256,7 @@ def display_transfer_status(task_id, new=False):
     faults = session['faults']
     dsid = session['dsid']
     
-    detail_uri = "https://www.globus.org/app/activity/{0}".format(task_id)
+    detail_uri = "{0}activity/{1}".format(MyGlobus['globusURL'], task_id)
     
     protocol = 'https://'
     redirect_uri = protocol + os.environ['HTTP_HOST'] + MyGlobus['redirect_uri']

--- a/src/cgi-bin/rdaGlobusTransfer.py
+++ b/src/cgi-bin/rdaGlobusTransfer.py
@@ -121,7 +121,7 @@ def transfer(form):
         'filelimit': 0,
         'folderlimit': 1,
         'cancelurl': cancelurl,
-        'label': 'NCAR RDA Globus transfer'
+        'label': ''
     }
 
     browse_endpoint = 'https://www.globus.org/app/browse-endpoint?{}'.format(urlencode(params))


### PR DESCRIPTION
There was an underscore character '_' in the Label field in the POST request to browse-endpoint.  This character appears to be illegal, so the default value for the Label field has been set to a blank string.