### PR TITLE
Deleted undefined variable

### DIFF
--- a/src/php/dsglobus.php
+++ b/src/php/dsglobus.php
@@ -350,7 +350,6 @@ function globus_cli_cmd($cmd) {
    if(!is_resource($proc)) {
       return pmessge("$cmd: error executing command", true);
    }
-   fwrite($pipes[0], $rinfo);
    fclose($pipes[0]);
 
    $out = stream_get_contents($pipes[1]);


### PR DESCRIPTION
The variable $rinfo was referenced in the function globus_cli_cmd, but not defined.  It is not needed, and therefore deleted.