### PR TITLE
Update dsglobus to Python 3

### DIFF
--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -183,6 +183,17 @@ def delete_endpoint_acl_rule(action, data):
 	else:
 		print_stdout = False
 
+	if (sys.version_info < (3, 0)):
+		globus_rid_str = unicode('globus_rid')
+		globus_url_str = unicode('globus_url')
+		delete_date_str = unicode('delete_date')
+		status_str = unicode('status')
+	else:
+		globus_rid_str = 'globus_rid'
+		globus_url_str = 'globus_url'
+		delete_date_str = 'delete_date'
+		status_str = 'status'
+		
 	if (action == 1):
 		try:
 			endpoint_id = MyGlobus['data_request_ep']
@@ -219,8 +230,8 @@ def delete_endpoint_acl_rule(action, data):
 					sys.exit("Error: {0}".format(msg))
 				return {'Error': msg}
 			else:
-				record = {unicode('globus_rid'): None,
-				          unicode('globus_url'): None}
+				record = {globus_rid_str: None,
+				          globus_url_str: None}
 				if rqst_rid:
 					myupdt('dsrqst', record, rqst_cond)
 				else:
@@ -229,8 +240,8 @@ def delete_endpoint_acl_rule(action, data):
 				share_cond = " WHERE rindex='{0}' AND status='ACTIVE'".format(ridx)
 				myshare = myget('goshare', ['*'], share_cond)
 				if (len(myshare) > 0):
-					share_record = {unicode('delete_date'): datetime.now().strftime("%Y-%m-%d"),
-				                    unicode('status'): 'DELETED'}
+					share_record = {delete_date_str: datetime.now().strftime("%Y-%m-%d"),
+				                    status_str: 'DELETED'}
 					myupdt('goshare', share_record, share_cond)
 
 	elif (action == 2):
@@ -257,8 +268,8 @@ def delete_endpoint_acl_rule(action, data):
 				return {'Error': msg}
 			else:
 				rule_id = myshare['globus_rid']
-				record = {unicode('delete_date'): datetime.now().strftime("%Y-%m-%d"),
-				          unicode('status'): 'DELETED'}
+				record = {delete_date_str: datetime.now().strftime("%Y-%m-%d"),
+				          status_str: 'DELETED'}
 				myupdt('goshare', record, cond)
 
 	try:
@@ -290,6 +301,11 @@ def delete_endpoint_acl_rule(action, data):
 def submit_dsrqst_transfer(data):
 	""" Submit a Globus transfer on behalf of the user.  For dsrqst 'push' transfers. """
 
+	if (sys.version_info < (3, 0)):
+		task_id_str = unicode('task_id')
+	else:
+		task_id_str = 'task_id'
+	
 	""" Get session ID from dsrqst record """
 	ridx = data['ridx']
 	cond = " WHERE rindex={0}".format(ridx)
@@ -346,7 +362,7 @@ def submit_dsrqst_transfer(data):
 	task_id = transfer.submit_transfer(transfer_data)['task_id']
 
 	""" Store task_id in request record """
-	record = [{unicode('task_id'): task_id}]
+	record = [{task_id_str: task_id}]
 	myupdt('dsrqst', record[0], cond)
 
 	if 'print' in data and data['print']:
@@ -518,6 +534,13 @@ def update_share_record(action, data):
 		print_stdout = data['print']
 	else:
 		print_stdout = False
+
+	if (sys.version_info < (3, 0)):
+		globus_rid_str = unicode('globus_rid')
+		globus_url_str = unicode('globus_url')
+	else:
+		globus_rid_str = 'globus_rid'
+		globus_url_str = 'globus_url'
 	
 	try:
 		globus_rid = data['globus_rid']
@@ -546,8 +569,8 @@ def update_share_record(action, data):
 		try:
 			ridx = data['ridx']
 			cond = " WHERE rindex='{0}'".format(ridx)
-			rqst_record = {unicode('globus_rid'): data['globus_rid'],
-			               unicode('globus_url'): data['globus_url']
+			rqst_record = {globus_rid_str: data['globus_rid'],
+			               globus_url_str: data['globus_url']
 			              }
 			myupdt('dsrqst', rqst_record, cond)
 			my_logger.info("[update_share_record] dsrqst record updated. Request index: {0}.  ACL rule ID: {1}.".format(ridx, globus_rid))

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -230,8 +230,8 @@ def delete_endpoint_acl_rule(action, data):
 					sys.exit("Error: {0}".format(msg))
 				return {'Error': msg}
 			else:
-				record = {globus_rid_str: None,
-				          globus_url_str: None}
+				record = {'globus_rid': None,
+				          'globus_url': None}
 				if rqst_rid:
 					myupdt('dsrqst', record, rqst_cond)
 				else:
@@ -240,8 +240,8 @@ def delete_endpoint_acl_rule(action, data):
 				share_cond = " WHERE rindex='{0}' AND status='ACTIVE'".format(ridx)
 				myshare = myget('goshare', ['*'], share_cond)
 				if (len(myshare) > 0):
-					share_record = {delete_date_str: datetime.now().strftime("%Y-%m-%d"),
-				                    status_str: 'DELETED'}
+					share_record = {'delete_date': datetime.now().strftime("%Y-%m-%d"),
+				                    'status': 'DELETED'}
 					myupdt('goshare', share_record, share_cond)
 
 	elif (action == 2):
@@ -268,8 +268,8 @@ def delete_endpoint_acl_rule(action, data):
 				return {'Error': msg}
 			else:
 				rule_id = myshare['globus_rid']
-				record = {delete_date_str: datetime.now().strftime("%Y-%m-%d"),
-				          status_str: 'DELETED'}
+				record = {'delete_date': datetime.now().strftime("%Y-%m-%d"),
+				          'status': 'DELETED'}
 				myupdt('goshare', record, cond)
 
 	try:
@@ -362,7 +362,7 @@ def submit_dsrqst_transfer(data):
 	task_id = transfer.submit_transfer(transfer_data)['task_id']
 
 	""" Store task_id in request record """
-	record = [{task_id_str: task_id}]
+	record = [{'task_id': task_id}]
 	myupdt('dsrqst', record[0], cond)
 
 	if 'print' in data and data['print']:
@@ -569,8 +569,8 @@ def update_share_record(action, data):
 		try:
 			ridx = data['ridx']
 			cond = " WHERE rindex='{0}'".format(ridx)
-			rqst_record = {globus_rid_str: data['globus_rid'],
-			               globus_url_str: data['globus_url']
+			rqst_record = {'globus_rid': data['globus_rid'],
+			               'globus_url': data['globus_url']
 			              }
 			myupdt('dsrqst', rqst_record, cond)
 			my_logger.info("[update_share_record] dsrqst record updated. Request index: {0}.  ACL rule ID: {1}.".format(ridx, globus_rid))

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -190,9 +190,9 @@ def delete_endpoint_acl_rule(action, data):
 		status_str = unicode('status')
 	else:
 		globus_rid_str = str(b'globus_rid', 'utf-8')
-		globus_url_str = str(b'globus_url')
-		delete_date_str = str(b'delete_date')
-		status_str = str(b'status')
+		globus_url_str = str(b'globus_url', 'utf-8')
+		delete_date_str = str(b'delete_date', 'utf-8')
+		status_str = str(b'status', 'utf-8')
 		
 	if (action == 1):
 		try:

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -23,7 +23,7 @@ import subprocess
 try:
 	assert sys.version_info >= (2, 7)
 except AssertionError:
-	print "Error: Python version 2.7 or later required."
+	print ("Error: Python version 2.7 or later required.")
 	raise
 
 path1 = "/glade/u/home/rdadata/lib/python"
@@ -159,7 +159,7 @@ def add_endpoint_acl_rule(action, data):
 	
 	msg = "{0}\nResource: {1}\nRequest ID: {2}\nAccess ID: {3}".format(result['message'], result['resource'], result['request_id'], result['access_id'])
 	if 'print' in data and data['print']:
-		print msg
+		print (msg)
 	my_logger.info("[add_endpoint_acl_rule] {0}".format(msg))
 	my_logger.info("[add_endpoint_acl_rule] User email: {0}".format(email))
 	
@@ -281,7 +281,7 @@ def delete_endpoint_acl_rule(action, data):
     
 	msg = "{0}\nResource: {1}\nRequest ID: {2}".format(result['message'], result['resource'], result['request_id'])
 	if 'print' in data and data['print']:
-		print msg
+		print (msg)
 	my_logger.info("[delete_endpoint_acl_rule] {0}".format(msg))
 	
 	return msg
@@ -350,7 +350,7 @@ def submit_dsrqst_transfer(data):
 	myupdt('dsrqst', record[0], cond)
 
 	if 'print' in data and data['print']:
-		print "{}".format(task_id)
+		print ("{}".format(task_id))
 
 	"""	Create share record in goshare """
 

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -219,8 +219,8 @@ def delete_endpoint_acl_rule(action, data):
 					sys.exit("Error: {0}".format(msg))
 				return {'Error': msg}
 			else:
-				record = {'globus_rid': None,
-				          'globus_url': None}
+				record = {unicode('globus_rid'): None,
+				          unicode('globus_url'): None}
 				if rqst_rid:
 					myupdt('dsrqst', record, rqst_cond)
 				else:
@@ -229,8 +229,8 @@ def delete_endpoint_acl_rule(action, data):
 				share_cond = " WHERE rindex='{0}' AND status='ACTIVE'".format(ridx)
 				myshare = myget('goshare', ['*'], share_cond)
 				if (len(myshare) > 0):
-					share_record = {'delete_date': datetime.now().strftime("%Y-%m-%d"),
-				                    'status': 'DELETED'}
+					share_record = {unicode('delete_date'): datetime.now().strftime("%Y-%m-%d"),
+				                    unicode('status'): 'DELETED'}
 					myupdt('goshare', share_record, share_cond)
 
 	elif (action == 2):
@@ -257,8 +257,8 @@ def delete_endpoint_acl_rule(action, data):
 				return {'Error': msg}
 			else:
 				rule_id = myshare['globus_rid']
-				record = {'delete_date': datetime.now().strftime("%Y-%m-%d"),
-				          'status': 'DELETED'}
+				record = {unicode('delete_date'): datetime.now().strftime("%Y-%m-%d"),
+				          unicode('status'): 'DELETED'}
 				myupdt('goshare', record, cond)
 
 	try:
@@ -346,7 +346,7 @@ def submit_dsrqst_transfer(data):
 	task_id = transfer.submit_transfer(transfer_data)['task_id']
 
 	""" Store task_id in request record """
-	record = [{'task_id': task_id}]
+	record = [{unicode('task_id'): task_id}]
 	myupdt('dsrqst', record[0], cond)
 
 	if 'print' in data and data['print']:
@@ -546,8 +546,8 @@ def update_share_record(action, data):
 		try:
 			ridx = data['ridx']
 			cond = " WHERE rindex='{0}'".format(ridx)
-			rqst_record = {'globus_rid': data['globus_rid'],
-			               'globus_url': data['globus_url']
+			rqst_record = {unicode('globus_rid'): data['globus_rid'],
+			               unicode('globus_url'): data['globus_url']
 			              }
 			myupdt('dsrqst', rqst_record, cond)
 			my_logger.info("[update_share_record] dsrqst record updated. Request index: {0}.  ACL rule ID: {1}.".format(ridx, globus_rid))

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -183,17 +183,6 @@ def delete_endpoint_acl_rule(action, data):
 	else:
 		print_stdout = False
 
-	if (sys.version_info < (3, 0)):
-		globus_rid_str = unicode('globus_rid')
-		globus_url_str = unicode('globus_url')
-		delete_date_str = unicode('delete_date')
-		status_str = unicode('status')
-	else:
-		globus_rid_str = str(b'globus_rid', 'utf-8')
-		globus_url_str = str(b'globus_url', 'utf-8')
-		delete_date_str = str(b'delete_date', 'utf-8')
-		status_str = str(b'status', 'utf-8')
-		
 	if (action == 1):
 		try:
 			endpoint_id = MyGlobus['data_request_ep']
@@ -301,11 +290,6 @@ def delete_endpoint_acl_rule(action, data):
 def submit_dsrqst_transfer(data):
 	""" Submit a Globus transfer on behalf of the user.  For dsrqst 'push' transfers. """
 
-	if (sys.version_info < (3, 0)):
-		task_id_str = unicode('task_id')
-	else:
-		task_id_str = str(b'task_id', 'utf-8')
-	
 	""" Get session ID from dsrqst record """
 	ridx = data['ridx']
 	cond = " WHERE rindex={0}".format(ridx)
@@ -535,13 +519,6 @@ def update_share_record(action, data):
 	else:
 		print_stdout = False
 
-	if (sys.version_info < (3, 0)):
-		globus_rid_str = unicode('globus_rid')
-		globus_url_str = unicode('globus_url')
-	else:
-		globus_rid_str = str(b'globus_rid', 'utf-8')
-		globus_url_str = str(b'globus_url', 'utf-8')
-	
 	try:
 		globus_rid = data['globus_rid']
 		globus_url = data['globus_url']

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -135,8 +135,8 @@ def add_endpoint_acl_rule(action, data):
 	    "path": path,
 	    "permissions": "r"
  	}
- 	if 'notify' in data:
- 		rule_data.update({"notify_email": email})	
+	if 'notify' in data:
+ 		rule_data.update({"notify_email": email})
 
 	try:
 		tc_authorizer = RefreshTokenAuthorizer(MyGlobus['transfer_refresh_token'], load_app_client())

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -219,8 +219,8 @@ def delete_endpoint_acl_rule(action, data):
 					sys.exit("Error: {0}".format(msg))
 				return {'Error': msg}
 			else:
-				record = {unicode('globus_rid'): None,
-				          unicode('globus_url'): None}
+				record = {'globus_rid': None,
+				          'globus_url': None}
 				if rqst_rid:
 					myupdt('dsrqst', record, rqst_cond)
 				else:
@@ -229,8 +229,8 @@ def delete_endpoint_acl_rule(action, data):
 				share_cond = " WHERE rindex='{0}' AND status='ACTIVE'".format(ridx)
 				myshare = myget('goshare', ['*'], share_cond)
 				if (len(myshare) > 0):
-					share_record = {unicode('delete_date'): datetime.now().strftime("%Y-%m-%d"),
-				                    unicode('status'): 'DELETED'}
+					share_record = {'delete_date': datetime.now().strftime("%Y-%m-%d"),
+				                    'status': 'DELETED'}
 					myupdt('goshare', share_record, share_cond)
 
 	elif (action == 2):
@@ -257,8 +257,8 @@ def delete_endpoint_acl_rule(action, data):
 				return {'Error': msg}
 			else:
 				rule_id = myshare['globus_rid']
-				record = {unicode('delete_date'): datetime.now().strftime("%Y-%m-%d"),
-				          unicode('status'): 'DELETED'}
+				record = {'delete_date': datetime.now().strftime("%Y-%m-%d"),
+				          'status': 'DELETED'}
 				myupdt('goshare', record, cond)
 
 	try:
@@ -346,7 +346,7 @@ def submit_dsrqst_transfer(data):
 	task_id = transfer.submit_transfer(transfer_data)['task_id']
 
 	""" Store task_id in request record """
-	record = [{unicode('task_id'): task_id}]
+	record = [{'task_id': task_id}]
 	myupdt('dsrqst', record[0], cond)
 
 	if 'print' in data and data['print']:
@@ -546,8 +546,8 @@ def update_share_record(action, data):
 		try:
 			ridx = data['ridx']
 			cond = " WHERE rindex='{0}'".format(ridx)
-			rqst_record = {unicode('globus_rid'): data['globus_rid'],
-			               unicode('globus_url'): data['globus_url']
+			rqst_record = {'globus_rid': data['globus_rid'],
+			               'globus_url': data['globus_url']
 			              }
 			myupdt('dsrqst', rqst_record, cond)
 			my_logger.info("[update_share_record] dsrqst record updated. Request index: {0}.  ACL rule ID: {1}.".format(ridx, globus_rid))

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -189,10 +189,10 @@ def delete_endpoint_acl_rule(action, data):
 		delete_date_str = unicode('delete_date')
 		status_str = unicode('status')
 	else:
-		globus_rid_str = 'globus_rid'
-		globus_url_str = 'globus_url'
-		delete_date_str = 'delete_date'
-		status_str = 'status'
+		globus_rid_str = str(b'globus_rid', 'utf-8')
+		globus_url_str = str(b'globus_url')
+		delete_date_str = str(b'delete_date')
+		status_str = str(b'status')
 		
 	if (action == 1):
 		try:
@@ -304,7 +304,7 @@ def submit_dsrqst_transfer(data):
 	if (sys.version_info < (3, 0)):
 		task_id_str = unicode('task_id')
 	else:
-		task_id_str = 'task_id'
+		task_id_str = str(b'task_id', 'utf-8')
 	
 	""" Get session ID from dsrqst record """
 	ridx = data['ridx']
@@ -539,8 +539,8 @@ def update_share_record(action, data):
 		globus_rid_str = unicode('globus_rid')
 		globus_url_str = unicode('globus_url')
 	else:
-		globus_rid_str = 'globus_rid'
-		globus_url_str = 'globus_url'
+		globus_rid_str = str(b'globus_rid', 'utf-8')
+		globus_url_str = str(b'globus_url', 'utf-8')
 	
 	try:
 		globus_rid = data['globus_rid']

--- a/src/python/lib/MyGlobus.py
+++ b/src/python/lib/MyGlobus.py
@@ -19,13 +19,17 @@ Include path to Globus SDK if on cheyenne login or compute nodes
 (or load the globus-sdk environment module via the command 'module load globus-sdk'),
 or on DAV systems
 """
-import sys, socket, re, platform
+import os, sys, socket, re, platform
 hostname = socket.gethostname()
 if ((hostname.find('cheyenne') != -1) or re.match(r'^r\d{1,2}', hostname)):
 	sdk_path_ch = "/glade/u/apps/ch/opt/pythonpkgs/2.7/globus-sdk/1.4.1/gnu/6.3.0/lib/python2.7/site-packages"
 	if (sdk_path_ch not in sys.path):
 		sys.path.append(sdk_path_ch)
-elif ( (hostname.find('geyser') != -1 or hostname.find('caldera') != -1 or hostname.find('pronghorn') != -1 or hostname.find('casper') != -1 or hostname.find('yslogin') != -1 or hostname.find('ysm') != -1) ):
+elif ( hostname.find('casper') != -1):
+	if (sys.version_info < (3, 0)):
+		sdk_path_casper = '/glade/u/apps/dav/opt/python/2.7.14/intel/17.0.1/pkg-library/20180510/lib/python2.7/site-packages'
+		sys.path.append(sdk_path_casper)
+elif ( (hostname.find('geyser') != -1 or hostname.find('caldera') != -1 or hostname.find('pronghorn') != -1 or hostname.find('yslogin') != -1 or hostname.find('ysm') != -1) ):
 	os_dist = platform.linux_distribution()[0]
 	if (re.match(r'^CentOS', os_dist)):
 		sdk_path_centos = '/glade/u/apps/dav/opt/python/2.7.14/intel/17.0.1/pkg-library/20180510/lib/python2.7/site-packages'

--- a/src/python/lib/PyDBI.py
+++ b/src/python/lib/PyDBI.py
@@ -152,7 +152,7 @@ def myadd(tablename, record, print_status=None):
 		fields = []
 		values = []
 		for key in record:
-			fields.append(str(key).encode('utf8'))
+			fields.append(str(key))
 		fields = "(" + ",".join(fields) + ")"
 		for val in record.values():
 			if val == None:
@@ -196,7 +196,7 @@ def myupdt(tablename, record, condition, print_status=None):
 		fields = []
 		values = []
 		for key in record:
-			field = str(key).encode('utf8')
+			field = str(key)
 			setstr = "{0}=%s".format(field)
 			fields.append(setstr)
 		fields = ",".join(fields)

--- a/src/python/lib/PyDBI.py
+++ b/src/python/lib/PyDBI.py
@@ -51,13 +51,13 @@ def dbconnect():
 		return db
 	except mysql.connector.Error as err:
 		if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-			print "Incorrect database user name/password combination"
+			print ("Incorrect database user name/password combination")
 			sys.exit(1)
 		elif err.errno == errorcode.ER_BAD_DB_ERROR:
-			print "Database %s does not exist" % dbconfig['database']
+			print ("Database {} does not exist".format(dbconfig['database']))
 			sys.exit(1)
 		else:
-			print "Error: ", err
+			print ("Error: {}".format(err))
 			sys.exit(1)
 
 #=========================================================================================
@@ -67,7 +67,7 @@ def dbclose(db):
 	try:
 		db.close()
 	except mysql.connector.Error as err:
-		print "Error %d" % err.errno
+		print ("Error {}".format(err.errno))
 		sys.exit(1)
 
 #=========================================================================================
@@ -99,7 +99,7 @@ def myget(tablename, fields, condition):
 		else:
 			return {}
 	except mysql.connector.Error as err:
-		print "Error: ", err
+		print ("Error: {}".format(err))
 		sys.exit(1)
 
 #=========================================================================================
@@ -135,7 +135,7 @@ def mymget(tablename, fields, condition):
 		else:
 			return {}
 	except mysql.connector.Error as err:
-		print "Error: ", err
+		print ("Error: {}".format(err))
 		sys.exit(1)
 
 #=========================================================================================
@@ -167,11 +167,11 @@ def myadd(tablename, record, print_status=None):
 		db.commit()
 		dbclose(db)
 		if print_status:
-			print "One record added to table %s" % tablename
+			print ("One record added to table {}".format(tablename))
 	except mysql.connector.Error as err:
-		print "table: "+tablename
-		print record
-		print "Error in myadd: ", err
+		print ("table: {}".format(tablename))
+		print (record)
+		print ("Error in myadd: {}".format(err))
 		sys.exit(1)
 		
 #=========================================================================================
@@ -215,11 +215,11 @@ def myupdt(tablename, record, condition, print_status=None):
 		db.commit()
 		dbclose(db)
 		if print_status:
-			print "One record updated in table %s" % tablename
+			print ("One record updated in table {}".format(tablename))
 	except mysql.connector.Error as err:
-		print record
-		print condition
-		print "Error in myupdt: ", err
+		print (record)
+		print (condition)
+		print ("Error in myupdt: {}".format(err))
 		sys.exit(1)
 
 #=========================================================================================


### PR DESCRIPTION
The default Python interpreter on casper is now Python 3.  This pull request brings the following scripts into Python 3 compliance, and is backward compatible with Python 2.7 on rda-data and rda-web-prod:

- dsglobus.py
- PyDBI.py
- MyGlobus.py