### PR TITLE
Updated to new browse endpoint URL

### DIFF
--- a/src/cgi-bin/rdaGlobusTransfer.py
+++ b/src/cgi-bin/rdaGlobusTransfer.py
@@ -136,7 +136,7 @@ def transfer(form):
         'label': ''
     }
 
-    browse_endpoint = '{0}browse-endpoint?{1}'.format(MyGlobus['globusURL'], urlencode(params))
+    browse_endpoint = '{0}file-manager?{1}'.format(MyGlobus['globusURL'], urlencode(params))
     print ("Location: {0}\r\n\r\n".format(browse_endpoint))
 
     return


### PR DESCRIPTION
URI for browse-endpoint was changed to app.globus.org/file-manager.  This fixes the broken link.  See https://docs.globus.org/api/helper-pages/browse-endpoint/