### PR TITLE
Verify checksum

### DIFF
--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -1368,8 +1368,8 @@ def parse_input():
 	    Required fields in the JSON input are 'action' (set to 'transfer'), 
 	    'source_endpoint', 'destination_endpoint', and 'files', specified as an array of
 	    JSON objects with 'source_file', and 'destination_file' key-value pairs.  The 
-	    field 'label' is optional.  JSON input can be passed into dsglobus in one of the 
-	    following ways:
+	    fields 'label' and 'verify_checksum' are optional.  JSON input can be passed into 
+	    dsglobus in one of the following ways:
 	    
 	    1. dsglobus < files.json
 	    2. cat files.json | dsglobus
@@ -1384,7 +1384,8 @@ def parse_input():
 	      "action": "transfer",
 	      "source_endpoint": "rda-glade",
 	      "destination_endpoint": "rda-quasar",
-	      "label": "RDA Quasar transfer"
+	      "label": "RDA Quasar transfer",
+	      "verify_checksum": True,
 	      "files": [
 	         {"source_file": "/data/ds999.9/file1.tar", "destination_file": "/ds999.9/file1.tar"},
 	         {"source_file": "/data/ds999.9/file2.tar", "destination_file": "/ds999.9/file2.tar"},

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -788,6 +788,8 @@ def submit_rda_transfer(data):
 		label = data['label']
 	except KeyError:
 		label=''
+	if 'verify_checksum' in data:
+		verify_checksum = data['verify_checksum']
 	try:
 		files = data['files']
 	except KeyError:
@@ -803,7 +805,8 @@ def submit_rda_transfer(data):
 	transfer_data = TransferData(transfer_client=tc,
 							     source_endpoint=source_endpoint,
 							     destination_endpoint=destination_endpoint,
-							     label=label)
+							     label=label,
+							     verify_checksum=verify_checksum)
 
 	for i in range(len(files)):
 		source_file = files[i]['source_file']
@@ -1415,6 +1418,7 @@ def parse_input():
 	parser.add_argument('--destination-endpoint', '-de', action="store", dest="DESTINATION_ENDPOINT", help='Destination endpoint ID or name.  Required with --transfer.')
 	parser.add_argument('--source-file', '-sf', action="store", dest="SOURCE_FILE", help='Path to source file name, relative to source endpoint host path.  Required with --transfer option.')
 	parser.add_argument('--destination-file', '-df', action="store", dest="DESTINATION_FILE", help='Path to destination file name, relative to destination endpoint host path.  Required with --transfer.')
+	parser.add_argument('--verify-checksum', '-vc', action="store_true", default=False, help='Verify checksum after transfer.  Default = False.')
 	parser.add_argument('--target-file', '-tf', action="store", dest="TARGET_FILE", help='Path to target file name, relative to endpoint host path.  Required with --delete.')
 	parser.add_argument('--path', '-p', action="store", dest="PATH", help='Directory path on endpoint.  Required with -ls argument.')
 	parser.add_argument('--filter', action="store", dest="FILTER_PATTERN", help='Filter applied to --list-files.')

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -790,6 +790,8 @@ def submit_rda_transfer(data):
 		label=''
 	if 'verify_checksum' in data:
 		verify_checksum = data['verify_checksum']
+	else:
+		verify_checksum = False
 	try:
 		files = data['files']
 	except KeyError:

--- a/src/python/dsglobus.py
+++ b/src/python/dsglobus.py
@@ -1021,6 +1021,7 @@ def get_task_info(data):
 		("Destination Endpoint ID", "destination_endpoint_id"),
 		("Bytes Transferred", "bytes_transferred"),
 		("Bytes Per Second", "effective_bytes_per_second"),
+		("Verify Checksum", "verify_checksum"),
 	]
 	successful_transfer_fields = [
 		("Source Path", "source_path"),
@@ -1267,7 +1268,7 @@ def parse_input():
 	    --transfer, --source-endpoint, --destination-endpoint, --source-file, and 
 	    --destination-file:
 	    
-	        dsglobus --transfer --source-endpoint 'rda-glade' --destination-endpoint 'rda-quasar' --source-file /ds999.9/file.txt --destination-file /ds999.9/file.txt
+	        dsglobus --transfer --source-endpoint 'rda-glade' --destination-endpoint 'rda-quasar' --source-file /data/ds999.9/file.txt --destination-file /ds999.9/file.txt
 	  			 
 	  - List files on the 'NCAR RDA Quasar' endpoint.  Required arguments: --list-files,
 	    --endpoint, --path:
@@ -1418,7 +1419,7 @@ def parse_input():
 	parser.add_argument('--destination-endpoint', '-de', action="store", dest="DESTINATION_ENDPOINT", help='Destination endpoint ID or name.  Required with --transfer.')
 	parser.add_argument('--source-file', '-sf', action="store", dest="SOURCE_FILE", help='Path to source file name, relative to source endpoint host path.  Required with --transfer option.')
 	parser.add_argument('--destination-file', '-df', action="store", dest="DESTINATION_FILE", help='Path to destination file name, relative to destination endpoint host path.  Required with --transfer.')
-	parser.add_argument('--verify-checksum', '-vc', action="store_true", default=False, help='Verify checksum after transfer.  Default = False.')
+	parser.add_argument('--verify-checksum', '-vc', action="store_true", default=False, help='Verify checksum after transfer.  Use with the --transfer action.  Default = False.')
 	parser.add_argument('--target-file', '-tf', action="store", dest="TARGET_FILE", help='Path to target file name, relative to endpoint host path.  Required with --delete.')
 	parser.add_argument('--path', '-p', action="store", dest="PATH", help='Directory path on endpoint.  Required with -ls argument.')
 	parser.add_argument('--filter', action="store", dest="FILTER_PATTERN", help='Filter applied to --list-files.')


### PR DESCRIPTION
Added the option --verify-checksum to verify the checksum on the source and destination files for transfers.  Globus will verify the checksums and re-transfer the file if the checksums don't match.  Used only with the --transfer option.  Default value is False.

More info in the Globus documentation at [https://globus-sdk-python.readthedocs.io/en/stable/clients/transfer.html#helper-objects](url)

For JSON input, set the key 'verify_checksum' to 'true':
"verify_checksum":true