### PR TITLE
Remove stratus endpoint

### DIFF
--- a/src/python/lib/MyGlobus.py
+++ b/src/python/lib/MyGlobus.py
@@ -57,7 +57,6 @@ RDA_GLADE_ENDPOINT = '7f0acd80-dfb2-4412-b7b5-ebc970bedf24'
 RDA_QUASAR_ENDPOINT = 'e50caa88-feae-11ea-81a2-0e2f230cc907'
 RDA_QUASAR_DR_ENDPOINT = '4c42c32c-feaf-11ea-81a2-0e2f230cc907'
 
-RDA_STRATUS_ENDPOINT = 'be4aa6a8-9e35-11eb-8a8e-d70d98a40c8d'
 GLOBUS_CGD_ENDPOINT_ID = '11651c26-80c2-4dac-a236-7755530731ac'
 
 GDEX_DATASET_ENDPOINT = 'c4e40965-a024-43d7-bef4-6010f3731b61'
@@ -66,7 +65,7 @@ GDEX_OS_ENDPOINT = '558ad782-80dd-4656-a64a-2245f38a7c9e' # GDEX Boreas object s
 
 
 """ Token storage adapters """
-RDA_QUASAR_TOKEN_STORAGE_ADAPTER = "/glade/u/home/gdexdata/lib/python/globus_rda_quasar_tokens.json"
+RDA_QUASAR_TOKEN_STORAGE_ADAPTER = "/glade/u/home/gdexdata/globus/globus_gdex_quasar_tokens.json"
 
 MyGlobus = {
    'url': GLOBUS_TRANSFER_BASE_URL,
@@ -76,7 +75,6 @@ MyGlobus = {
    'data_request_ep' : RDA_DSRQST_ENDPOINT,
    'datashare_legacy' : 'rda#datashare',
    'data_request_legacy' : 'rda#data_request',
-   'datashare_stratus' : 'rda#stratus',
    'datashare_ep_base' : RDA_DATA_PATH + '/data/',
    'data_request_ep_base' : RDA_DATA_PATH + '/transfer/',
    'host_endpoint_id' : NCAR_HOST_ENDPOINT,
@@ -89,8 +87,7 @@ MyGlobus = {
    'rda_quasar_client_id': RDA_QUASAR_CLIENT_ID,
    'rda_glade_endpoint': RDA_GLADE_ENDPOINT,
    'quasar_endpoint': RDA_QUASAR_ENDPOINT,
-   'quasar_dr_endpoint': RDA_QUASAR_DR_ENDPOINT,
-   'rda_stratus_endpoint': RDA_STRATUS_ENDPOINT
+   'quasar_dr_endpoint': RDA_QUASAR_DR_ENDPOINT
 }
 
 # Endpoint dict mapping endpoint display names and aliases to endpoint IDs
@@ -100,15 +97,12 @@ MyEndpoints = {
     'NCAR RDA GLADE': RDA_GLADE_ENDPOINT,
     'NCAR RDA Quasar': RDA_QUASAR_ENDPOINT,
     'NCAR RDA Quasar DRDATA': RDA_QUASAR_DR_ENDPOINT,
-    'NCAR RDA Stratus': RDA_STRATUS_ENDPOINT,
     'rda-glade': RDA_GLADE_ENDPOINT,
     'rda-quasar': RDA_QUASAR_ENDPOINT,
     'rda-quasar-drdata': RDA_QUASAR_DR_ENDPOINT,
-    'rda-stratus': RDA_STRATUS_ENDPOINT,
     'rda-cgd': GLOBUS_CGD_ENDPOINT_ID,
     'rda#datashare': RDA_DATASET_ENDPOINT,
     'rda#data_request': RDA_DSRQST_ENDPOINT,
-    'rda#stratus': RDA_STRATUS_ENDPOINT,
     'rda#cgd': GLOBUS_CGD_ENDPOINT_ID,
 	'gdex-data': GDEX_DATASET_ENDPOINT,
     'gdex-request': GDEX_DSRQST_ENDPOINT,

--- a/src/python/retrieve_globus_metrics.py
+++ b/src/python/retrieve_globus_metrics.py
@@ -39,14 +39,13 @@ import logging.handlers
 my_logger = logging.getLogger(__name__)
 
 # All valid endpoints
-all_endpoints = ['gdex-data', 'gdex-request', 'gdex-os', 'rda#datashare', 'rda#stratus']
+all_endpoints = ['gdex-data', 'gdex-request', 'gdex-os', 'rda#datashare']
 
 # Endpoint UUIDs
 endpoint_id_gdex_data = MyEndpoints['gdex-data']
 endpoint_id_gdex_os = MyEndpoints['gdex-os']
 endpoint_id_data_request = MyEndpoints['gdex-request']
 endpoint_id_datashare = MyEndpoints['rda#datashare']
-endpoint_id_stratus = MyEndpoints['rda#stratus']
 
 #=========================================================================================
 def main(opts):


### PR DESCRIPTION
This pull request removes all references to the Stratus endpoint from the codebase, streamlining endpoint management and eliminating unused configuration and code paths. Additionally, it updates the path for the Quasar token storage adapter to a new location.

**Endpoint cleanup and configuration updates:**

* Removed the `RDA_STRATUS_ENDPOINT` constant and all related references from the `MyGlobus` configuration dictionary and endpoint mapping in `src/python/lib/MyGlobus.py`. [[1]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L60) [[2]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L79) [[3]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L92-R90) [[4]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L103-L111)
* Removed Stratus-related entries from the endpoint display name and alias mapping in `src/python/lib/MyGlobus.py`.
* Removed Stratus from the list of valid endpoints and deleted its endpoint ID assignment in `src/python/retrieve_globus_metrics.py`.

**Token storage path update:**

* Updated the `RDA_QUASAR_TOKEN_STORAGE_ADAPTER` path to a new location in `src/python/lib/MyGlobus.py`.