### PR TITLE
Add logic to check for task type

### DIFF
--- a/src/python/retrieve_globus_metrics.py
+++ b/src/python/retrieve_globus_metrics.py
@@ -114,7 +114,8 @@ def get_tasks(filters):
 		tc_authorizer = RefreshTokenAuthorizer(MyGlobus['transfer_refresh_token'], load_app_client())
 		tc = TransferClient(authorizer=tc_authorizer)
 		for task in tc.paginated.endpoint_manager_task_list(**filters).items():
-			tasks.append(task)
+			if task['type'] == 'SUCCEEDED':
+				tasks.append(task)
 	except GlobusAPIError as e:
 		msg = ("[get_tasks] Globus API Error\n"
 		       "HTTP status: {}\n"


### PR DESCRIPTION
This pull request introduces a small change to the filtering logic in the `get_tasks` function in `src/python/retrieve_globus_metrics.py`. The change ensures that only tasks with a `'type'` value of `'SUCCEEDED'` are appended to the task list.