### PR TITLE
Remove deprecated guest collections

### DIFF
--- a/src/python/lib/MyGlobus.py
+++ b/src/python/lib/MyGlobus.py
@@ -35,10 +35,13 @@ GLOBUS_AUTH_BASE_URL = 'https://auth.globus.org/v2/'
 GLOBUS_APP_URL = 'https://app.globus.org/'
 GLOBUS_SHARE_URL = 'https://app.globus.org/file-manager'
 REDIRECT_URI = '/cgi-bin/rdaGlobusTransfer'
-RDA_DATA_PATH = '/glade/campaign/collections/gdex'
+GDEX_DATA_PATH = '/glade/campaign/collections/gdex'
+RDA_DATA_PATH = GDEX_DATA_PATH
+GDEX_WORK_PATH = '/lustre/desc1/gdex'
+
 
 """ Set up logging directory """
-workdir = os.path.join(RDA_DATA_PATH, 'work/tcram')
+workdir = os.path.join(GDEX_WORK_PATH, 'work/tcram')
 logdir = os.environ.get('LOGDIR', workdir)
 LOGPATH = os.path.join(logdir, 'globus')
 
@@ -49,11 +52,7 @@ GLOBUS_REQUEST_DOMAIN = 'https://request.gdex.ucar.edu'
 CGD_HTTPS_DOMAIN = 'https://g-09c647.7a577b.6fbd.data.globus.org'
 
 """ Endpoint IDs """
-RDA_DATASET_ENDPOINT = 'b6b5d5e8-eb14-4f6b-8928-c02429d67998'
-RDA_DSRQST_ENDPOINT = 'e6cd9f43-935c-42e3-8d19-764d03241719'
 NCAR_HOST_ENDPOINT = 'dd1ee92a-6d04-11e5-ba46-22000b92c6ec'
-
-RDA_GLADE_ENDPOINT = '7f0acd80-dfb2-4412-b7b5-ebc970bedf24'
 RDA_QUASAR_ENDPOINT = 'e50caa88-feae-11ea-81a2-0e2f230cc907'
 RDA_QUASAR_DR_ENDPOINT = '4c42c32c-feaf-11ea-81a2-0e2f230cc907'
 
@@ -71,12 +70,6 @@ MyGlobus = {
    'url': GLOBUS_TRANSFER_BASE_URL,
    'transfer_refresh_token': TRANSFER_REFRESH_TOKEN,
    'auth_refresh_token': AUTH_REFRESH_TOKEN,
-   'datashare_ep': RDA_DATASET_ENDPOINT,
-   'data_request_ep' : RDA_DSRQST_ENDPOINT,
-   'datashare_legacy' : 'rda#datashare',
-   'data_request_legacy' : 'rda#data_request',
-   'datashare_ep_base' : RDA_DATA_PATH + '/data/',
-   'data_request_ep_base' : RDA_DATA_PATH + '/transfer/',
    'host_endpoint_id' : NCAR_HOST_ENDPOINT,
    'client_id': CLIENT_ID,
    'client_secret': CLIENT_SECRET,
@@ -85,24 +78,17 @@ MyGlobus = {
    'globusURL': GLOBUS_APP_URL,
    'globus_share_url': GLOBUS_SHARE_URL,
    'rda_quasar_client_id': RDA_QUASAR_CLIENT_ID,
-   'rda_glade_endpoint': RDA_GLADE_ENDPOINT,
    'quasar_endpoint': RDA_QUASAR_ENDPOINT,
    'quasar_dr_endpoint': RDA_QUASAR_DR_ENDPOINT
 }
 
 # Endpoint dict mapping endpoint display names and aliases to endpoint IDs
 MyEndpoints = {
-    'NCAR RDA Data Requests': RDA_DSRQST_ENDPOINT,
-    'NCAR RDA Dataset Archive': RDA_DATASET_ENDPOINT,
-    'NCAR RDA GLADE': RDA_GLADE_ENDPOINT,
     'NCAR RDA Quasar': RDA_QUASAR_ENDPOINT,
     'NCAR RDA Quasar DRDATA': RDA_QUASAR_DR_ENDPOINT,
-    'rda-glade': RDA_GLADE_ENDPOINT,
     'rda-quasar': RDA_QUASAR_ENDPOINT,
     'rda-quasar-drdata': RDA_QUASAR_DR_ENDPOINT,
     'rda-cgd': GLOBUS_CGD_ENDPOINT_ID,
-    'rda#datashare': RDA_DATASET_ENDPOINT,
-    'rda#data_request': RDA_DSRQST_ENDPOINT,
     'rda#cgd': GLOBUS_CGD_ENDPOINT_ID,
 	'gdex-data': GDEX_DATASET_ENDPOINT,
     'gdex-request': GDEX_DSRQST_ENDPOINT,

--- a/src/python/retrieve_globus_metrics.py
+++ b/src/python/retrieve_globus_metrics.py
@@ -511,8 +511,8 @@ def update_allusage(task_id):
 			usage_record.update(task_record)
 			all_recs.append(usage_record)
 	else:
-		my_logger.info(f"[update_allusage] Task ID {task_id} not found in table gofile. Adding/updating record in allusage with dsid=ds000.0")
-		usage_record = {'dsid': 'ds000.0', 'size': bytes_transferred}
+		my_logger.info(f"[update_allusage] Task ID {task_id} not found in table gofile. Adding/updating record in allusage with dsid=d000000")
+		usage_record = {'dsid': 'd000000', 'size': bytes_transferred}
 		usage_record.update(task_record)
 		all_recs.append(usage_record)
 

--- a/src/python/retrieve_globus_metrics.py
+++ b/src/python/retrieve_globus_metrics.py
@@ -45,7 +45,6 @@ all_endpoints = ['gdex-data', 'gdex-request', 'gdex-os']
 endpoint_id_gdex_data = MyEndpoints['gdex-data']
 endpoint_id_gdex_os = MyEndpoints['gdex-os']
 endpoint_id_data_request = MyEndpoints['gdex-request']
-endpoint_id_datashare = MyEndpoints['rda#datashare']
 
 #=========================================================================================
 def main(opts):
@@ -95,7 +94,7 @@ def main(opts):
 						my_logger.warning(msg)
 						cache_email_logmsg(msg)
 					# Update usage from gdex-data and gdex-os endpoints into table allusage
-					if (endpoint_id in [endpoint_id_datashare, endpoint_id_gdex_data, endpoint_id_gdex_os]):
+					if (endpoint_id in [endpoint_id_gdex_data, endpoint_id_gdex_os]):
 						update_allusage(task_id)
 		else:
 			msg = f"No transfer tasks found for endpoint {ep} ({filters['filter_endpoint']}) and date range {filters['filter_completion_time']}"
@@ -270,7 +269,7 @@ def prepare_transfer_recs(data, task_id, bytes, endpoint):
 		data_type = data[i]['DATA_TYPE']
 		pathsplit = source_path.split("/")
 
-		if (endpoint in [endpoint_id_datashare, endpoint_id_gdex_data, endpoint_id_gdex_os]):
+		if (endpoint in [endpoint_id_gdex_data, endpoint_id_gdex_os]):
 			# Query file size from wfile_dnnnnnn.data_size
 		    
 			# Get dsid from source_path
@@ -383,7 +382,7 @@ def add_successful_transfers(go_table, data, task_id, bytes, endpoint):
 		if searchObj:
 			continue
 		else:
-			if (endpoint in [endpoint_id_datashare, endpoint_id_gdex_data, endpoint_id_gdex_os]):
+			if (endpoint in [endpoint_id_gdex_data, endpoint_id_gdex_os]):
 				condition = f"task_id='{records[i]['task_id']}' AND source_path='{records[i]['source_path']}'"
 				myrec = pgget(go_table, keys_str, condition)
 				if (len(myrec) > 0):
@@ -594,10 +593,6 @@ def map_endpoint_names(data):
 			data[i]['source_endpoint'] = 'gdex-os'
 		if source_endpoint_id == MyEndpoints['gdex-request']:
 			data[i]['source_endpoint'] = 'gdex-request'
-		if source_endpoint_id == MyEndpoints['rda#datashare']:
-			data[i]['source_endpoint'] = 'rda#datashare'
-		if source_endpoint_id == MyEndpoints['rda#data_request']:
-			data[i]['source_endpoint'] = 'rda#data_request'
 	return data
 
 #=========================================================================================
@@ -786,12 +781,12 @@ def parse_opts():
 	desc = "Get Globus task transfer metrics from the Globus Transfer API and store the metrics in RDADB."	
 	epilog = textwrap.dedent('''\
 	Example:
-	  - Retrieve transfer metrics for endpoint rda#datashare between 1 Jan - 31 Jan 2017:
-	              retrieve_globus_metrics.py -n datashare -s 2017-01-01 -e 2017-01-31	
+	  - Retrieve transfer metrics for endpoint gdex-data between 1 Jan - 31 Jan 2026:
+	              retrieve_globus_metrics.py -n gdex-data -s 2026-01-01 -e 2026-01-31	
 	''')
 
 	parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=desc, epilog=textwrap.dedent(epilog))
-	parser.add_argument('-n', '--endpoint-name', action="store", required=False, nargs='*', choices=['datashare', 'data_request', 'gdex-data', 'gdex-request', 'gdex-os'], help="GDEX guest collection canonical name. Valid names are 'gdex-data', 'gdex-request','datashare', 'data_request', and 'gdex-os'. Multiple names can be provided, separated by white space (e.g. -n datashare gdex-data).")
+	parser.add_argument('-n', '--endpoint-name', action="store", required=False, nargs='*', choices=['gdex-data', 'gdex-request', 'gdex-os'], help="GDEX guest collection canonical name. Valid names are 'gdex-data', 'gdex-request', and 'gdex-os'. Multiple names can be provided, separated by white space (e.g. -n gdex-data gdex-os).")
 	parser.add_argument('-o', '--owner-id', action="store", help='A Globus Auth identity id.')
 	parser.add_argument('-s', '--start-date', action="store", help='Begin date for search.  Default is 30 days prior.')
 	parser.add_argument('-e', '--end-date', action="store", help='End date for search.  Default is current date.')
@@ -807,10 +802,12 @@ def parse_opts():
 			parser.error('A maximum of 6 endpoint names is allowed.')
 
 		for ep in opts['endpoint_name']:
-			if(re.search(r'datashare', ep)):
-				endpoint = 'rda#datashare'
-			elif(re.search(r'data_request', ep)):
+			if(re.search(r'gdex-data', ep)):
+				endpoint = 'gdex-data'
+			elif(re.search(r'gdex-request', ep)):
 				endpoint = 'gdex-request'
+			elif(re.search(r'gdex-os', ep)):
+				endpoint = 'gdex-os'
 			else:
 				endpoint = ep
 			endpoints.append(endpoint)


### PR DESCRIPTION
This pull request updates the codebase to remove all references to legacy RDA endpoints and collections, fully transitioning to the new GDEX endpoints and paths. The changes ensure that only GDEX endpoints are supported and referenced throughout the configuration, logic, and user interface.

**Major changes include:**

### Migration from RDA to GDEX endpoints and paths

* Removed all references to legacy RDA endpoints (e.g., `RDA_DATASET_ENDPOINT`, `RDA_DSRQST_ENDPOINT`, `RDA_GLADE_ENDPOINT`) and related legacy names from `MyGlobus.py` and `retrieve_globus_metrics.py`. Only GDEX endpoints (`gdex-data`, `gdex-request`, `gdex-os`) are now supported and referenced. [[1]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L52-L56) [[2]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L74-L79) [[3]](diffhunk://#diff-bcae06859c123cb687f63ff6dd78c998732f02de291514209e95fbd6c23718b2L88-L105) [[4]](diffhunk://#diff-b95b590d22fb075af54bf21f3cb87767a8c6e4d2d0805e85206993ccd6f04c86L48) [[5]](diffhunk://#diff-b95b590d22fb075af54bf21f3cb87767a8c6e4d2d0805e85206993ccd6f04c86L597-L600) [[6]](diffhunk://#diff-b95b590d22fb075af54bf21f3cb87767a8c6e4d2d0805e85206993ccd6f04c86L810-R810)
* Updated all data path and working directory variables to use GDEX paths (`GDEX_DATA_PATH`, `GDEX_WORK_PATH`) instead of RDA paths.

### Logic and filtering updates

* Updated all conditional logic in `retrieve_globus_metrics.py` to only check for GDEX endpoints, removing checks and handling for legacy RDA endpoints. [[1]](diffhunk://#diff-b95b590d22fb075af54bf21f3cb87767a8c6e4d2d0805e85206993ccd6f04c86L98-R97) [[2]](diffhunk://#diff-b95b590d22fb075af54bf21f3cb87767a8c6e4d2d0805e85206993ccd6f04c86L273-R272) [[3]](diffhunk://#diff-b95b590d22fb075af54bf21f3cb87767a8c6e4d2d0805e85206993ccd6f04c86L386-R385)

### User interface and argument handling

* Updated command-line argument choices and help text to only list GDEX endpoints, removing `datashare` and `data_request` as valid options.
* Updated example usage in documentation to reference GDEX endpoints and dates.
* Updated endpoint name normalization logic to only map GDEX endpoint names.